### PR TITLE
Update QQ.php

### DIFF
--- a/src/Provider/QQ.php
+++ b/src/Provider/QQ.php
@@ -61,6 +61,11 @@ class QQ extends OAuth2
     /**
      * {@inheritdoc}
      */
+    protected $responseDataFormat = 'json';
+    
+    /**
+     * {@inheritdoc}
+     */
     protected function initialize()
     {
         parent::initialize();
@@ -73,7 +78,8 @@ class QQ extends OAuth2
         }
 
         $this->apiRequestParameters = [
-            'access_token' => $this->getStoredData('access_token')
+            'access_token' => $this->getStoredData('access_token'),
+            'fmt' => $this>responseDataFormat
         ];
 
         $this->apiRequestHeaders = [];
@@ -87,18 +93,12 @@ class QQ extends OAuth2
         $collection = parent::validateAccessTokenExchange($response);
 
         $resp = $this->apiRequest($this->accessTokenInfoUrl);
-        $resp = key($resp);
 
-        $len = strlen($resp);
-        $res = substr($resp, 10, $len - 14);
-
-        $response = (new Data\Parser())->parse($res);
-
-        if (!isset($response->openid)) {
+        if (!isset($resp->openid)) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
-        $this->storeData('openid', $response->openid);
+        $this->storeData('openid', $resp->openid);
 
         return $collection;
     }
@@ -113,7 +113,7 @@ class QQ extends OAuth2
         $userRequestParameters = [
             'oauth_consumer_key' => $this->clientId,
             'openid' => $openid,
-            'format' => 'json'
+            'format' => $this>responseDataFormat
         ];
 
         $response = $this->apiRequest($this->accessUserInfo, 'GET', $userRequestParameters);


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | NO
| Patch: Bug Fix?          |  Fix QQ can't parse to get openid
| Major: Breaking Change?  | No
| Minor: New Feature?      | No

<!-- Describe your changes below in as much detail as possible -->
<!-- For documentation fixes, pls create a PR in https://github.com/hybridauth/hybridauth.github.io -->

According to QQ documentation: [获取用户openid_oauth2-0](https://wiki.connect.qq.com/%e8%8e%b7%e5%8f%96%e7%94%a8%e6%88%b7openid_oauth2-0)
| Params                        | Require     |    Describe
| ------------- | ---------- | ----------
| access_token           | Y| 在Step1中获取到的access token。
| fmt          |  N | 因历史原因，默认是jsonpb格式，如果填写json，则返回json格式


Request interface: https://graph.qq.com/oauth2.0/me can provide a valid parameter `fmt` to specify the return format. Currently, the `json` return format is supported, and the original processing method has been unable to resolve and obtain the openid normally.

Therefore, make the following modifications: 
-  Add the response data formatting property `responseDataFormat`
-  Modify the initialization method
-  Modify the original processing method
  
Please check the commit for details.  

